### PR TITLE
Season page

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,12 +1,18 @@
-import {Box, Title, Header as MantineHeader, Flex, Paper, Space, Input} from "@mantine/core";
+import {
+  Box,
+  Title,
+  Header as MantineHeader,
+  Flex,
+  Paper,
+  Space,
+  Input,
+} from "@mantine/core";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import LoginButton from "./LoginButton";
-import Searchbar from "./Searchbar"
-import ButtonSeason from './ButtonSeason'
-import {
-    IconCheck,
-} from "@tabler/icons"
+import Searchbar from "./Searchbar";
+import ButtonSeason from "./ButtonSeason";
+import { IconCheck } from "@tabler/icons";
 
 const Header = () => {
   const session = useSession();
@@ -21,49 +27,34 @@ const Header = () => {
         alignItems: "center",
       })}
     >
-        <Flex direction={"column"} align={"center"} sx={{width: "100%"}}>
-            <Flex mt={10} justify={"center"} align={"center"} sx={{width: "100%"}}>
-                <Title fw={"400"} mr={30} tt={"uppercase"} c={'white'} fz={"md"}>
-                    <IconCheck size={18}/> fri frakt från sverige
-                </Title>
+      <Flex direction={"column"} align={"center"} sx={{ width: "100%" }}>
+        <Flex
+          mt={10}
+          justify={"center"}
+          align={"center"}
+          sx={{ width: "100%" }}
+        >
+          <Title fw={"400"} mr={30} tt={"uppercase"} c={"white"} fz={"md"}>
+            <IconCheck size={18} /> fri frakt från sverige
+          </Title>
 
-                    <Space w={"lg"}/>
+          <Space w={"lg"} />
 
-                <Title fw={"400"} ml={30} tt={"uppercase"} c={"white"} fz={"md"}>
-                   <IconCheck size={18}/> 100% vegan
-                </Title>
-            </Flex>
-
-            <Flex justify={"space-between"} sx={{width: "100%"}}>
-
-              <Searchbar/>
-
-              <Link href="/">
-                <Title size='xxx-large' mr={230} pt={20} color="white">
-                  MakeUpByS
-                </Title>
-              </Link>
-                
-                <LoginButton />
-
-            </Flex>
-
-            <Flex>
-                <ButtonSeason />
-            </Flex>
+          <Title fw={"400"} ml={30} tt={"uppercase"} c={"white"} fz={"md"}>
+            <IconCheck size={18} /> 100% vegan
+          </Title>
         </Flex>
 
         <Flex justify={"space-between"} sx={{ width: "100%" }}>
-          <Box>Sök...</Box>
+          <Searchbar />
 
           <Link href="/">
-            <Title size="xxx-large" ml={10} order={2} color="white">
+            <Title size="xxx-large" mr={230} pt={20} color="white">
               MakeUpByS
             </Title>
           </Link>
-          <Box>
-            <LoginButton />
-          </Box>
+
+          <LoginButton />
         </Flex>
 
         <Flex>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,12 +1,17 @@
-import {Box, Title, Header as MantineHeader, Flex, Paper, Space} from "@mantine/core";
+import {
+  Box,
+  Title,
+  Header as MantineHeader,
+  Flex,
+  Paper,
+  Space,
+} from "@mantine/core";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import LoginButton from "./LoginButton";
-import ButtonSeason from './ButtonSeason'
-import {
-    IconCheck,
-} from "@tabler/icons"
-import {toUpperCase} from "uri-js/dist/esnext/util";
+import ButtonSeason from "./ButtonSeason";
+import { IconCheck } from "@tabler/icons";
+import { toUpperCase } from "uri-js/dist/esnext/util";
 
 const Header = () => {
   const session = useSession();
@@ -21,37 +26,34 @@ const Header = () => {
         alignItems: "center",
       })}
     >
-        <Flex direction={"column"} align={"center"} sx={{width: "100%"}}>
-            <Flex justify={"center"} align={"center"} sx={{width: "100%"}}>
-                <Title tt={"uppercase"} c={'white'} fz={"md"}>
-                    <IconCheck/> fri frakt från sverige
-                </Title>
-                    <Space w={"md"}/>
-                <Title tt={"uppercase"} c={"white"} fz={"md"}>
-                   <IconCheck/> 100% vegan
-                </Title>
-            </Flex>
-
-            <Flex justify={"space-between"} sx={{width: "100%"}}>
-
-                <Box>
-                    Sök...
-                </Box>
-
-              <Link href="/">
-                <Title size='xxx-large' ml={10} order={2} color="white">
-                  MakeUpByS
-                </Title>
-              </Link>
-                <Box >
-                  <LoginButton />
-                </Box>
-            </Flex>
-
-            <Flex>
-                <ButtonSeason />
-            </Flex>
+      <Flex direction={"column"} align={"center"} sx={{ width: "100%" }}>
+        <Flex justify={"center"} align={"center"} sx={{ width: "100%" }}>
+          <Title tt={"uppercase"} c={"white"} fz={"md"}>
+            <IconCheck /> fri frakt från sverige
+          </Title>
+          <Space w={"md"} />
+          <Title tt={"uppercase"} c={"white"} fz={"md"}>
+            <IconCheck /> 100% vegan
+          </Title>
         </Flex>
+
+        <Flex justify={"space-between"} sx={{ width: "100%" }}>
+          <Box>Sök...</Box>
+
+          <Link href="/">
+            <Title size="xxx-large" ml={10} order={2} color="white">
+              MakeUpByS
+            </Title>
+          </Link>
+          <Box>
+            <LoginButton />
+          </Box>
+        </Flex>
+
+        <Flex>
+          <ButtonSeason />
+        </Flex>
+      </Flex>
 
       <Flex gap={10}>
         {session.data?.user ? <Link href="/mypage">Mina sidor</Link> : null}

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,0 +1,16 @@
+import { Flex, Title } from "@mantine/core";
+import { FC } from "react";
+
+type Props = {
+  product: any;
+};
+
+const ProductCard: FC<Props> = ({ product }) => {
+  return (
+    <Flex m="lg" wrap="wrap" justify={"center"}>
+      <Title order={3}>{product.title}</Title>
+    </Flex>
+  );
+};
+
+export default ProductCard;

--- a/pages/api/open/subproduct/season/[slug].ts
+++ b/pages/api/open/subproduct/season/[slug].ts
@@ -34,10 +34,14 @@ export default async function handler(
           .populate({
             path: "colors",
             model: Color,
-            populate: { path: "seasons", model: Season },
+            populate: {
+              path: "seasons",
+              model: Season,
+              //match: { slug: { $in: slug } },  // Check why this doesnt work!
+            },
           });
 
-        // easier way?
+        // Find a better way. Should be able to filter the query above
         let list: any = [];
         subProducts.forEach((product) => {
           product.colors.forEach((color: ColorDocument) => {

--- a/pages/api/open/subproduct/season/[slug].ts
+++ b/pages/api/open/subproduct/season/[slug].ts
@@ -1,0 +1,58 @@
+import dbConnect from "../../../../../utils/dbConnect";
+import SubProduct, {
+  SubProductDocument,
+} from "../../../../../models/SubProduct";
+import { NextApiRequest, NextApiResponse } from "next";
+import MainProduct from "../../../../../models/MainProduct";
+import Category from "../../../../../models/Category";
+import Color, { ColorDocument } from "../../../../../models/Color";
+import Season, { SeasonDocument } from "../../../../../models/Season";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const {
+    query: { slug },
+    method,
+  } = req;
+
+  await dbConnect();
+
+  switch (method) {
+    case "GET":
+      try {
+        const subProducts = await SubProduct.find({})
+          .populate({
+            path: "mainProduct",
+            model: MainProduct,
+            populate: {
+              path: "category",
+              model: Category,
+            },
+          })
+          .populate({
+            path: "colors",
+            model: Color,
+            populate: { path: "seasons", model: Season },
+          });
+
+        // easier way?
+        let list: any = [];
+        subProducts.forEach((product) => {
+          product.colors.forEach((color: ColorDocument) => {
+            color.seasons.forEach((season: any) => {
+              if (season.slug == slug) {
+                list.push(product);
+              }
+            });
+          });
+        });
+
+        res.status(200).json({ success: true, data: list });
+      } catch (error) {
+        res.status(400).json({ success: false, data: error });
+      }
+      break;
+  }
+}

--- a/pages/api/open/subproduct/season/[slug].ts
+++ b/pages/api/open/subproduct/season/[slug].ts
@@ -41,6 +41,19 @@ export default async function handler(
             },
           });
 
+        /* 
+
+arrayOfElements.map((element) => {
+  return {
+    ...element,
+    subElements: element.subElements.filter(
+      (subElement) => subElement.surname === 1
+    ),
+  };
+}); 
+
+*/
+
         // Find a better way. Should be able to filter the query above
         let list: any = [];
         subProducts.forEach((product) => {

--- a/pages/season/[slug].tsx
+++ b/pages/season/[slug].tsx
@@ -1,17 +1,19 @@
-import { AppShell, Title, Box } from "@mantine/core";
+import { AppShell, Title, Box, Flex, Text } from "@mantine/core";
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
+import { SeasonDocument } from "../../models/Season";
 import SubProduct, { SubProductDocument } from "../../models/SubProduct";
 import dbConnect from "../../utils/dbConnect";
 
 type Props = {
   products: any;
+  season: any;
 };
 
-const Season: NextPage<Props> = ({ products }) => {
+const Season: NextPage<Props> = ({ products, season }) => {
   const router = useRouter();
   const { slug } = router.query;
 
@@ -21,7 +23,19 @@ const Season: NextPage<Props> = ({ products }) => {
     <>
       <AppShell fixed={false} header={<Header />} footer={<Footer />}>
         <Box style={{ marginTop: 60, minHeight: "100vh" }}>
-          <Title order={1}>{slug}</Title>
+          <Flex direction={"column"} align="center" sx={{ width: "100%" }}>
+            <Title order={1}>{season?.data?.title}</Title>
+            <Text>{season?.data?.description}</Text>
+          </Flex>
+          <Flex>
+            {products?.data?.map((product: any, index: number) => {
+              return (
+                <Title key={index} order={3}>
+                  {product.title}
+                </Title>
+              );
+            })}
+          </Flex>
         </Box>
       </AppShell>
     </>
@@ -46,17 +60,22 @@ interface IParams extends ParsedUrlQuery {
 export const getStaticProps: GetStaticProps = async (context) => {
   await dbConnect();
 
-  // todo: Fix domain in .env.local
   const { slug } = context.params as IParams;
-  const response = await fetch(
-    `http://localhost:3000/api/open/subproduct/season/${slug}`
+  const getProductsBySeason = await fetch(
+    `${process.env.NEXT_DOMAIN}/api/open/subproduct/season/${slug}`
   );
 
-  const products = await response.json();
+  const getSeason = await fetch(
+    `${process.env.NEXT_DOMAIN}/api/open/season/${slug}`
+  );
+
+  const season = await getSeason.json();
+  const products = await getProductsBySeason.json();
 
   return {
     props: {
       products,
+      season,
     },
   };
 };

--- a/pages/season/[slug].tsx
+++ b/pages/season/[slug].tsx
@@ -4,9 +4,6 @@ import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
-import Category from "../../models/Category";
-import Color from "../../models/Color";
-import MainProduct from "../../models/MainProduct";
 import SubProduct, { SubProductDocument } from "../../models/SubProduct";
 import dbConnect from "../../utils/dbConnect";
 
@@ -27,7 +24,6 @@ const Season: NextPage<Props> = ({ products }) => {
           <Title order={1}>{slug}</Title>
         </Box>
       </AppShell>
-      <Header />
     </>
   );
 };

--- a/pages/season/[slug].tsx
+++ b/pages/season/[slug].tsx
@@ -1,10 +1,11 @@
-import { AppShell, Title, Box, Flex, Text, Button } from "@mantine/core";
+import { AppShell, Title, Box, Flex, Text, Button, Grid } from "@mantine/core";
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
+import ProductCard from "../../components/ProductCard";
 import { CategoryDocument } from "../../models/Category";
 import { SeasonDocument } from "../../models/Season";
 import SubProduct, { SubProductDocument } from "../../models/SubProduct";
@@ -59,15 +60,15 @@ const Season: NextPage<Props> = ({ products, season }) => {
             })}
           </Flex>
           <Flex wrap="wrap" justify={"center"}>
-            {products?.data?.map((product: any, index: number) => {
-              return (
-                <Flex m="lg" wrap="wrap">
-                  <Title key={index} order={3}>
-                    {product.title}
-                  </Title>
-                </Flex>
-              );
-            })}
+            <Grid justify={"center"}>
+              {products?.data?.map((product: any, index: number) => {
+                return (
+                  <Grid.Col key={index} span={4}>
+                    <ProductCard product={product} />
+                  </Grid.Col>
+                );
+              })}
+            </Grid>
           </Flex>
         </Box>
       </AppShell>

--- a/pages/season/[slug].tsx
+++ b/pages/season/[slug].tsx
@@ -1,0 +1,67 @@
+import { AppShell, Title, Box } from "@mantine/core";
+import { GetStaticPaths, GetStaticProps, NextPage } from "next";
+import { useRouter } from "next/router";
+import { ParsedUrlQuery } from "querystring";
+import Footer from "../../components/Footer";
+import Header from "../../components/Header";
+import Category from "../../models/Category";
+import Color from "../../models/Color";
+import MainProduct from "../../models/MainProduct";
+import SubProduct, { SubProductDocument } from "../../models/SubProduct";
+import dbConnect from "../../utils/dbConnect";
+
+type Props = {
+  products: any;
+};
+
+const Season: NextPage<Props> = ({ products }) => {
+  const router = useRouter();
+  const { slug } = router.query;
+
+  console.log(products);
+
+  return (
+    <>
+      <AppShell fixed={false} header={<Header />} footer={<Footer />}>
+        <Box style={{ marginTop: 60, minHeight: "100vh" }}>
+          <Title order={1}>{slug}</Title>
+        </Box>
+      </AppShell>
+      <Header />
+    </>
+  );
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  await dbConnect();
+  const products: SubProductDocument[] = await SubProduct.find({});
+
+  const paths = products.map((product) => ({
+    params: { slug: product.slug },
+  }));
+
+  return { paths, fallback: true };
+};
+
+interface IParams extends ParsedUrlQuery {
+  slug: string;
+}
+
+export const getStaticProps: GetStaticProps = async (context) => {
+  await dbConnect();
+
+  // todo: Fix domain in .env.local
+  const { slug } = context.params as IParams;
+  const response = await fetch(
+    `http://localhost:3000/api/open/subproduct/season/${slug}`
+  );
+
+  const products = await response.json();
+
+  return {
+    props: {
+      products,
+    },
+  };
+};
+export default Season;

--- a/pages/season/[slug].tsx
+++ b/pages/season/[slug].tsx
@@ -58,12 +58,14 @@ const Season: NextPage<Props> = ({ products, season }) => {
               );
             })}
           </Flex>
-          <Flex>
+          <Flex wrap="wrap" justify={"center"}>
             {products?.data?.map((product: any, index: number) => {
               return (
-                <Title key={index} order={3}>
-                  {product.title}
-                </Title>
+                <Flex m="lg" wrap="wrap">
+                  <Title key={index} order={3}>
+                    {product.title}
+                  </Title>
+                </Flex>
               );
             })}
           </Flex>

--- a/pages/season/[slug].tsx
+++ b/pages/season/[slug].tsx
@@ -1,9 +1,11 @@
-import { AppShell, Title, Box, Flex, Text } from "@mantine/core";
+import { AppShell, Title, Box, Flex, Text, Button } from "@mantine/core";
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
+import { CategoryDocument } from "../../models/Category";
 import { SeasonDocument } from "../../models/Season";
 import SubProduct, { SubProductDocument } from "../../models/SubProduct";
 import dbConnect from "../../utils/dbConnect";
@@ -17,7 +19,25 @@ const Season: NextPage<Props> = ({ products, season }) => {
   const router = useRouter();
   const { slug } = router.query;
 
-  console.log(products);
+  const path = "cate";
+
+  // Gets available categories on the list of products
+  let categories: CategoryDocument[] = [];
+  if (products?.data) {
+    products.data.forEach((product: any) => {
+      if (categories.length < 1) {
+        categories.push(product.mainProduct.category);
+        return;
+      }
+      const findCategory = categories.find(
+        (category) => category.title == product.mainProduct.category.title
+      );
+      if (!findCategory) {
+        categories.push(product.mainProduct.category);
+        return;
+      }
+    });
+  }
 
   return (
     <>
@@ -26,6 +46,17 @@ const Season: NextPage<Props> = ({ products, season }) => {
           <Flex direction={"column"} align="center" sx={{ width: "100%" }}>
             <Title order={1}>{season?.data?.title}</Title>
             <Text>{season?.data?.description}</Text>
+          </Flex>
+          <Flex justify={"center"} mt="sm" mb="xl" gap="lg">
+            {categories.map((category) => {
+              return (
+                <Link href={`/season/${slug}/category/${category.slug}`}>
+                  <Button variant="outline" color="brand.2">
+                    {category.title}
+                  </Button>
+                </Link>
+              );
+            })}
           </Flex>
           <Flex>
             {products?.data?.map((product: any, index: number) => {

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -34,7 +34,7 @@ export const getTheme = (colorScheme: ColorScheme): MantineThemeOverride => ({
       "#375F69", // "ljusblå" - theme.colors.brand[6]       *
       "#1D464E", // mellanblå  - theme.colors.brand[7]      *
       "#133136", // mörkblå  - theme.colors.brand[8]
-      "#000000", // Svart  - theme.colors.brand[9]
+      "#CFA6A1", // bakgrund säsongsknappar  - theme.colors.brand[9]
     ],
   },
   // Ex. theme.fontSizes.sm i applikationen. Dessa värden kan vi ändra så att de passar vår applikation bättre sen


### PR DESCRIPTION
#17 

exempel slug:
/season/var

* Sidladdningen blir en aning långsam när den hämtar produkterna, så jag behöver kolla upp hur jag gör det snabbare. Men lämnar den delen så länge och börjar fokusera på layouten så att den ser bra ut i och med att det ändå funkar. Funderar på om man skall lägga produkterna i en provider eller något för att inte behöva hämta varje gång man går in på en sida. Värt att diskutera, för det kanske inte är best practice :) 

* Produktkorten har jag bara börjat med att visa en titel så länge bara för att se vilka och hur många produkter det är. 

* Kategorierna är filtrerade på de faktiska produkterna, så om det inte finns någon produkt på tex läppstift så syns inte kategorin läppstift, då vi inte vill gå till en tom sida. 

Jag kommer skapa nya issues till produktkorten och fetchdelen, då båda kan ta en stund. 



![Skärmavbild 2022-12-30 kl  11 00 15](https://user-images.githubusercontent.com/90898648/210057997-99a9a4e1-7b04-4828-b27a-ca1f51692576.png)
