### PR TITLE
Header on scroll

### DIFF
--- a/components/ButtonSeason.tsx
+++ b/components/ButtonSeason.tsx
@@ -1,59 +1,89 @@
-import {Flex, Button} from "@mantine/core";
+import { Flex, Button } from "@mantine/core";
 import Link from "next/link";
 
-
 const ButtonSeason = () => {
-    return (
-        <Flex
-            mih={100}
-            gap='md'
-            justify='center'
-            align='center'
-            direction={{base: 'row', sm: 'row'}}
-            sx={(theme) => ({
-                [theme.fn.smallerThan("xs")]: {
-                    display: "none",
-                }
-            })}
+  return (
+    <Flex
+      //mih={100}
+      mt={20}
+      gap="md"
+      justify="center"
+      align="center"
+      direction={{ base: "row", sm: "row" }}
+      sx={(theme) => ({
+        /*  [theme.fn.smallerThan("sm")]: {
+          height: 60,
+        }, */
+        [theme.fn.smallerThan("xs")]: {
+          display: "none",
+        },
+      })}
+    >
+      <Link href={`/season/var`}>
+        <Button
+          sx={(theme) => ({
+            backgroundColor: theme.colors.brand[9],
+            borderColor: theme.colors.brand[0],
+            color: theme.colors.brand[0],
+            [theme.fn.smallerThan("sm")]: {
+              minWidth: "100px",
+              height: 28,
+            },
+          })}
         >
-            <Link href={`/season/var`}>
-            <Button sx={(theme) => ({backgroundColor: theme.colors.brand[9],
-                borderColor: theme.colors.brand[0],
-                color: theme.colors.brand[0],
-                [theme.fn.smallerThan("sm")]: {
-                    minWidth: "100px",
-                }
-                })}>vår</Button>
-            </Link>
+          vår
+        </Button>
+      </Link>
 
-            <Link href={`/season/sommar`}>
-            <Button sx={(theme) => ({backgroundColor: theme.colors.brand[9],
-                borderColor: theme.colors.brand[0],
-                color: theme.colors.brand[0],
-                [theme.fn.smallerThan("sm")]: {
-                    minWidth: "100px",
-                }})}>sommar</Button>
-            </Link>
+      <Link href={`/season/sommar`}>
+        <Button
+          sx={(theme) => ({
+            backgroundColor: theme.colors.brand[9],
+            borderColor: theme.colors.brand[0],
+            color: theme.colors.brand[0],
+            [theme.fn.smallerThan("sm")]: {
+              minWidth: "100px",
+              height: 28,
+            },
+          })}
+        >
+          sommar
+        </Button>
+      </Link>
 
-            <Link href={`/season/host`}>
-            <Button sx={(theme) => ({backgroundColor: theme.colors.brand[9],
-                borderColor: theme.colors.brand[0],
-                color: theme.colors.brand[0],
-                [theme.fn.smallerThan("sm")]: {
-                    minWidth: "100px",
-                }})}>höst</Button>
-            </Link>
+      <Link href={`/season/host`}>
+        <Button
+          sx={(theme) => ({
+            backgroundColor: theme.colors.brand[9],
+            borderColor: theme.colors.brand[0],
+            color: theme.colors.brand[0],
+            [theme.fn.smallerThan("sm")]: {
+              minWidth: "100px",
+              height: 28,
+            },
+          })}
+        >
+          höst
+        </Button>
+      </Link>
 
-            <Link href={`/season/vinter`}>
-            <Button sx={(theme) => ({backgroundColor: theme.colors.brand[9],
-                borderColor: theme.colors.brand[0],
-                color: theme.colors.brand[0],
-                [theme.fn.smallerThan("sm")]: {
-                    minWidth: "100px",
-                }})}>vinter</Button>
-            </Link>
-        </Flex>
-    )
-}
+      <Link href={`/season/vinter`}>
+        <Button
+          sx={(theme) => ({
+            backgroundColor: theme.colors.brand[9],
+            borderColor: theme.colors.brand[0],
+            color: theme.colors.brand[0],
+            [theme.fn.smallerThan("sm")]: {
+              minWidth: "100px",
+              height: 28,
+            },
+          })}
+        >
+          vinter
+        </Button>
+      </Link>
+    </Flex>
+  );
+};
 
-export default ButtonSeason
+export default ButtonSeason;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,7 +5,6 @@ import {
   Space,
   MediaQuery,
   Text,
-  Box,
 } from "@mantine/core";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
@@ -54,20 +53,26 @@ const Header = () => {
           display: "flex",
           justifyContent: "space-between",
           borderBottom: "none",
-          alignItems: "center",
-          height: hide ? 160 : 200,
+          height: hide ? 150 : 200,
+          paddingTop: 10,
+          [theme.fn.smallerThan("md")]: {
+            height: hide ? 150 : 180,
+            paddingTop: hide ? 20 : 10,
+          },
           [theme.fn.smallerThan("sm")]: {
-            paddingTop: hide ? 10 : "unset",
-            height: hide ? 140 : 170,
+            height: hide ? 135 : 150,
+            paddingTop: hide ? 25 : 10,
           },
           [theme.fn.smallerThan("xs")]: {
             height: hide ? "75px" : "85px",
+            alignItems: hide ? "center" : "flex-start",
+            paddingTop: hide ? 0 : 10,
           },
         })}
       >
         <Flex direction={"column"} align={"center"} sx={{ width: "100%" }}>
           <Flex
-            justify={"center"}
+            justify={"space-around"}
             align={"center"}
             sx={(theme) => ({
               display: hide ? "none" : "flex",
@@ -76,25 +81,24 @@ const Header = () => {
             })}
           >
             <Flex
-              align={"center"}
-              sx={(theme) => ({
-                [theme.fn.smallerThan("xs")]: {
-                  display: "none",
-                },
-              })}
+              gap={20}
+              justify={"center"}
+              align="center"
+              sx={(theme) => ({ width: "100%" })}
             >
-              <Flex>
+              <Flex align={"center"} gap={5}>
                 <IconCheck color="white" size={18} />
                 <Text
-                  ml={5}
                   fw={"400"}
-                  mr={30}
                   tt={"uppercase"}
                   c={"white"}
                   fz={"md"}
                   sx={(theme) => ({
                     [theme.fn.smallerThan("sm")]: {
                       fontSize: 14,
+                    },
+                    [theme.fn.smallerThan("xs")]: {
+                      fontSize: 11,
                     },
                   })}
                 >
@@ -105,12 +109,10 @@ const Header = () => {
               <MediaQuery smallerThan={"xs"} styles={{ display: "none" }}>
                 <Space w={"lg"} />
               </MediaQuery>
-              <Flex>
+              <Flex align={"center"} gap={5}>
                 <IconCheck color="white" size={18} />
                 <Text
-                  ml={5}
                   fw={"400"}
-                  mr={30}
                   tt={"uppercase"}
                   c={"white"}
                   fz={"md"}
@@ -118,39 +120,11 @@ const Header = () => {
                     [theme.fn.smallerThan("sm")]: {
                       fontSize: 14,
                     },
+                    [theme.fn.smallerThan("xs")]: {
+                      fontSize: 11,
+                    },
                   })}
                 >
-                  100% vegan
-                </Text>
-              </Flex>
-            </Flex>
-
-            <Flex
-              sx={(theme) => ({
-                alignItems: "center",
-                justifyContent: "space-around",
-                [theme.fn.largerThan("xs")]: {
-                  display: "none",
-                },
-              })}
-            >
-              <Flex align={"center"}>
-                <IconCheck color="white" size={12} />
-                <Text
-                  ml={10}
-                  mr={30}
-                  tt={"uppercase"}
-                  color={"white"}
-                  size={11}
-                >
-                  fri frakt från sverige
-                </Text>
-              </Flex>
-
-              <Space w={"lg"} />
-              <Flex align={"center"}>
-                <IconCheck color="white" size={12} />
-                <Text ml={10} tt={"uppercase"} c={"white"} size={11}>
                   100% vegan
                 </Text>
               </Flex>
@@ -158,14 +132,18 @@ const Header = () => {
           </Flex>
 
           <Flex
-            pt={20}
+            pt={22}
             justify={"space-between"}
             align="flex-end"
             sx={(theme) => ({
               width: "100%",
-              paddingTop: hide ? 0 : 20,
-              [theme.fn.smallerThan("xs")]: {
+              paddingTop: hide ? 0 : 22,
+              [theme.fn.smallerThan("md")]: {
                 paddingTop: hide ? 0 : 10,
+              },
+              [theme.fn.smallerThan("xs")]: {
+                alignItems: "center",
+                paddingTop: hide ? 0 : 15,
               },
             })}
           >
@@ -175,42 +153,24 @@ const Header = () => {
             <MobileBurgerMenu />
 
             <Link href="/">
-              {session.data?.user ? (
-                <Title
-                  fw={500}
-                  size="xxx-large"
-                  color="white"
-                  sx={(theme) => ({
-                    [theme.fn.smallerThan("lg")]: {},
-                    [theme.fn.smallerThan("md")]: {},
-                    [theme.fn.smallerThan("sm")]: {
-                      fontSize: "xx-large",
-                    },
-                    [theme.fn.smallerThan("xs")]: {},
-                  })}
-                >
-                  MakeUpByS
-                </Title>
-              ) : (
-                <Title
-                  fw={500}
-                  size="xxx-large"
-                  color="white"
-                  sx={(theme) => ({
-                    [theme.fn.smallerThan("lg")]: {},
-                    [theme.fn.smallerThan("md")]: {},
-                    [theme.fn.smallerThan("sm")]: {
-                      fontSize: "xx-large",
-                    },
-                    [theme.fn.smallerThan("xs")]: {
-                      paddingTop: hide ? 0 : 7,
-                      fontSize: "x-large",
-                    },
-                  })}
-                >
-                  MakeUpByS
-                </Title>
-              )}
+              <Title
+                fw={500}
+                size={48}
+                color="white"
+                sx={(theme) => ({
+                  [theme.fn.smallerThan("md")]: {
+                    fontSize: 43,
+                  },
+                  [theme.fn.smallerThan("sm")]: {
+                    fontSize: 35,
+                  },
+                  [theme.fn.smallerThan("xs")]: {
+                    fontSize: "x-large",
+                  },
+                })}
+              >
+                MakeUpByS
+              </Title>
             </Link>
             <LoginButton />
             <MobileLoginButton />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,6 +4,8 @@ import {
   Flex,
   Space,
   MediaQuery,
+  Text,
+  Box,
 } from "@mantine/core";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
@@ -14,104 +16,156 @@ import { IconCheck } from "@tabler/icons";
 import SearchbarMobile from "./SearchbarMobile";
 import MobileLoginButton from "./MobileLoginButtons";
 import MobileBurgerMenu from "./MobileBurgerMenu";
+import { useEffect, useRef, useState } from "react";
 
 const Header = () => {
   const session = useSession();
+  const [scrollY, setScrollY] = useState<number>(0);
+  const [hide, setHide] = useState<boolean>(false);
+
+  // Refs
+  const valueRef = useRef<any | null>();
+  valueRef.current = scrollY;
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  });
+
+  const handleScroll = () => {
+    setScrollY(window.scrollY);
+    let previousScrollY = valueRef.current;
+
+    if (previousScrollY < window.scrollY) {
+      setHide(true);
+    } else {
+      setHide(false);
+    }
+  };
 
   return (
     <>
       <MantineHeader
-        fixed={false}
-        height={220}
-        px={100}
+        fixed={true}
+        height={200}
+        px={20}
         sx={(theme) => ({
           backgroundColor: theme.colors.brand[2],
           display: "flex",
           justifyContent: "space-between",
           borderBottom: "none",
           alignItems: "center",
-          [theme.fn.smallerThan("lg")]: {
-            paddingLeft: "30px",
-            paddingRight: "30px",
+          height: hide ? 160 : 200,
+          [theme.fn.smallerThan("sm")]: {
+            paddingTop: hide ? 10 : "unset",
+            height: hide ? 140 : 170,
           },
           [theme.fn.smallerThan("xs")]: {
-            height: "120px",
+            height: hide ? "75px" : "85px",
           },
         })}
       >
         <Flex direction={"column"} align={"center"} sx={{ width: "100%" }}>
           <Flex
-            mt={10}
             justify={"center"}
             align={"center"}
             sx={(theme) => ({
+              display: hide ? "none" : "flex",
               width: "100%",
-              [theme.fn.smallerThan("xs")]: {
-                alignContent: "flex-start",
-                top: "0px",
-                position: "absolute",
-              },
+              [theme.fn.smallerThan("xs")]: {},
             })}
           >
             <Flex
+              align={"center"}
               sx={(theme) => ({
                 [theme.fn.smallerThan("xs")]: {
                   display: "none",
                 },
               })}
             >
-              <Title fw={"400"} mr={30} tt={"uppercase"} c={"white"} fz={"md"}>
-                <IconCheck size={18} /> fri frakt från sverige
-              </Title>
+              <Flex>
+                <IconCheck color="white" size={18} />
+                <Text
+                  ml={5}
+                  fw={"400"}
+                  mr={30}
+                  tt={"uppercase"}
+                  c={"white"}
+                  fz={"md"}
+                  sx={(theme) => ({
+                    [theme.fn.smallerThan("sm")]: {
+                      fontSize: 14,
+                    },
+                  })}
+                >
+                  fri frakt från sverige
+                </Text>
+              </Flex>
 
               <MediaQuery smallerThan={"xs"} styles={{ display: "none" }}>
                 <Space w={"lg"} />
               </MediaQuery>
-
-              <Title fw={"400"} ml={10} tt={"uppercase"} c={"white"} fz={"md"}>
-                <IconCheck size={18} /> 100% vegan
-              </Title>
+              <Flex>
+                <IconCheck color="white" size={18} />
+                <Text
+                  ml={5}
+                  fw={"400"}
+                  mr={30}
+                  tt={"uppercase"}
+                  c={"white"}
+                  fz={"md"}
+                  sx={(theme) => ({
+                    [theme.fn.smallerThan("sm")]: {
+                      fontSize: 14,
+                    },
+                  })}
+                >
+                  100% vegan
+                </Text>
+              </Flex>
             </Flex>
 
             <Flex
               sx={(theme) => ({
+                alignItems: "center",
+                justifyContent: "space-around",
                 [theme.fn.largerThan("xs")]: {
                   display: "none",
                 },
               })}
             >
-              <Title
-                fw={"400"}
-                mr={30}
-                tt={"uppercase"}
-                c={"white"}
-                fz={"12px"}
-              >
-                <IconCheck size={12} /> fri frakt från sverige
-              </Title>
+              <Flex align={"center"}>
+                <IconCheck color="white" size={12} />
+                <Text
+                  ml={10}
+                  mr={30}
+                  tt={"uppercase"}
+                  color={"white"}
+                  size={11}
+                >
+                  fri frakt från sverige
+                </Text>
+              </Flex>
 
               <Space w={"lg"} />
-
-              <Title
-                fw={"400"}
-                ml={10}
-                tt={"uppercase"}
-                c={"white"}
-                fz={"12px"}
-              >
-                <IconCheck size={12} /> 100% vegan
-              </Title>
+              <Flex align={"center"}>
+                <IconCheck color="white" size={12} />
+                <Text ml={10} tt={"uppercase"} c={"white"} size={11}>
+                  100% vegan
+                </Text>
+              </Flex>
             </Flex>
           </Flex>
 
           <Flex
+            pt={20}
             justify={"space-between"}
-            px={15}
+            align="flex-end"
             sx={(theme) => ({
               width: "100%",
+              paddingTop: hide ? 0 : 20,
               [theme.fn.smallerThan("xs")]: {
-                position: "absolute",
-                top: "60px",
+                paddingTop: hide ? 0 : 10,
               },
             })}
           >
@@ -125,24 +179,14 @@ const Header = () => {
                 <Title
                   fw={500}
                   size="xxx-large"
-                  pt={25}
                   color="white"
                   sx={(theme) => ({
-                    [theme.fn.smallerThan("lg")]: {
-                      paddingRight: "70px",
-                    },
-                    [theme.fn.smallerThan("md")]: {
-                      paddingRight: "10px",
-                    },
+                    [theme.fn.smallerThan("lg")]: {},
+                    [theme.fn.smallerThan("md")]: {},
                     [theme.fn.smallerThan("sm")]: {
                       fontSize: "xx-large",
-                      paddingRight: "0px",
-                      paddingLeft: "20px",
                     },
-                    [theme.fn.smallerThan("xs")]: {
-                      paddingTop: "5px",
-                      fontSize: "x-large",
-                    },
+                    [theme.fn.smallerThan("xs")]: {},
                   })}
                 >
                   MakeUpByS
@@ -151,23 +195,15 @@ const Header = () => {
                 <Title
                   fw={500}
                   size="xxx-large"
-                  pt={20}
                   color="white"
                   sx={(theme) => ({
-                    [theme.fn.smallerThan("lg")]: {
-                      paddingRight: "70px",
-                    },
-                    [theme.fn.smallerThan("md")]: {
-                      paddingRight: "10px",
-                    },
+                    [theme.fn.smallerThan("lg")]: {},
+                    [theme.fn.smallerThan("md")]: {},
                     [theme.fn.smallerThan("sm")]: {
                       fontSize: "xx-large",
-                      paddingRight: "0px",
-                      paddingLeft: "20px",
                     },
                     [theme.fn.smallerThan("xs")]: {
-                      paddingTop: "5px",
-                      paddingLeft: "5px",
+                      paddingTop: hide ? 0 : 7,
                       fontSize: "x-large",
                     },
                   })}
@@ -187,6 +223,7 @@ const Header = () => {
 
       <MediaQuery largerThan="xs" styles={{ display: "none" }}>
         <Flex
+          mt={85}
           sx={(theme) => ({
             backgroundColor: theme.colors.brand[2],
           })}

--- a/components/LoginButton.tsx
+++ b/components/LoginButton.tsx
@@ -48,10 +48,11 @@ const LoginButton: FC = () => {
         direction="row"
         sx={(theme) => ({
           zIndex: 2,
+          gap: session.data?.user.admin ? 10 : 16,
           [theme.fn.smallerThan("lg")]: {
             minWidth: "180px",
           },
-          [theme.fn.smallerThan("lg")]: {
+          [theme.fn.smallerThan("sm")]: {
             minWidth: "150px",
           },
           [theme.fn.smallerThan("xs")]: {
@@ -61,13 +62,15 @@ const LoginButton: FC = () => {
       >
         {session.data?.user ? (
           <Link href="/minsida">
-            <Box sx={{ height: 20 }}>
-              <ThemeIcon color="teal" variant="light" radius="xl" size={14}>
-                <IconCheck size={8} />
-              </ThemeIcon>
-            </Box>
-            <Box ref={ref}>
-              <IconUser color={hovered ? "#CC9887" : "white"} size={36} />
+            <Box pos="relative">
+              <Box pos={"absolute"} top={-17} left={-1} sx={{ height: 20 }}>
+                <ThemeIcon color="teal" variant="light" radius="xl" size={14}>
+                  <IconCheck size={8} />
+                </ThemeIcon>
+              </Box>
+              <Box ref={ref}>
+                <IconUser color={hovered ? "#CC9887" : "white"} size={36} />
+              </Box>
             </Box>
           </Link>
         ) : (

--- a/components/LoginButton.tsx
+++ b/components/LoginButton.tsx
@@ -43,13 +43,16 @@ const LoginButton: FC = () => {
       <Flex
         miw={250}
         gap={"md"}
-        justify="center"
+        justify="flex-end"
         align="flex-end"
         direction="row"
         sx={(theme) => ({
           zIndex: 2,
           [theme.fn.smallerThan("lg")]: {
             minWidth: "180px",
+          },
+          [theme.fn.smallerThan("lg")]: {
+            minWidth: "150px",
           },
           [theme.fn.smallerThan("xs")]: {
             display: "none",

--- a/components/MobileBurgerMenu.tsx
+++ b/components/MobileBurgerMenu.tsx
@@ -54,7 +54,7 @@ const MobileBurgerMenu: FC = () => {
   return (
     <>
       <MediaQuery largerThan="xs" styles={{ display: "none" }}>
-        <Flex sx={{ alignItems: "flex-end", paddingBottom: "2px" }}>
+        <Flex sx={{ alignItems: "flex-end", paddingBottom: "2px", width: 58 }}>
           <Burger
             left={"20px"}
             color="white"

--- a/components/MobileBurgerMenu.tsx
+++ b/components/MobileBurgerMenu.tsx
@@ -54,7 +54,12 @@ const MobileBurgerMenu: FC = () => {
   return (
     <>
       <MediaQuery largerThan="xs" styles={{ display: "none" }}>
-        <Flex sx={{ alignItems: "flex-end", paddingBottom: "2px", width: 58 }}>
+        <Flex
+          sx={{
+            alignItems: "center",
+            width: 58,
+          }}
+        >
           <Burger
             left={"20px"}
             color="white"

--- a/components/MobileLoginButtons.tsx
+++ b/components/MobileLoginButtons.tsx
@@ -51,26 +51,22 @@ const MobileLoginButton: FC = () => {
       >
         {session.data?.user ? (
           <Link href="/minsida">
-            <Flex sx={{ height: 7 }}>
-              <ThemeIcon color="teal" variant="light" radius="xl" size={8}>
-                <IconCheck size={6} />
-              </ThemeIcon>
-            </Flex>
-            <Box ref={ref}>
-              <IconUser color={hovered ? "#CC9887" : "white"} size={24} />
+            <Box pos={"relative"}>
+              <Flex pos={"absolute"} top={-6} sx={{ height: 7 }}>
+                <ThemeIcon color="teal" variant="light" radius="xl" size={8}>
+                  <IconCheck size={6} />
+                </ThemeIcon>
+              </Flex>
+              <Box ref={ref}>
+                <IconUser color={hovered ? "#CC9887" : "white"} size={26} />
+              </Box>
             </Box>
           </Link>
         ) : (
           <Link href="/">
-            <IconUser size={24} color="white" onClick={() => signIn()} />
+            <IconUser size={26} color="white" onClick={() => signIn()} />
           </Link>
         )}
-
-        {session.data?.user.admin ? (
-          <Link href="/admin">
-            <IconHomeCog size={24} color="white" />
-          </Link>
-        ) : null}
 
         <Box pos={"relative"}>
           {quantity && quantity > 0 ? (

--- a/components/Searchbar.tsx
+++ b/components/Searchbar.tsx
@@ -3,11 +3,16 @@ import { IconSearch, IconX } from "@tabler/icons";
 
 const Searchbar = () => {
   return (
-    <Flex align="flex-end" direction="row" sx={(theme) => ({
-      [theme.fn.smallerThan("xs")]: {
-        display: "none",
-      },
-    })}>
+    <Flex
+      mb={8}
+      align="flex-end"
+      direction="row"
+      sx={(theme) => ({
+        [theme.fn.smallerThan("xs")]: {
+          display: "none",
+        },
+      })}
+    >
       <Flex
         mr={5}
         align="flex-end"
@@ -29,7 +34,7 @@ const Searchbar = () => {
         variant="unstyled"
         data={["Smink", "Läppstift"]}
         sx={(theme) => ({
-          [theme.fn.smallerThan("md")]: {
+          [theme.fn.smallerThan("lg")]: {
             minWidth: "180px",
           },
           [theme.fn.smallerThan("sm")]: {
@@ -42,7 +47,7 @@ const Searchbar = () => {
         styles={{
           input: {
             borderBottom: "1px solid white",
-            color: "white"
+            color: "white",
           },
         }}
       ></Autocomplete>

--- a/components/SearchbarMobile.tsx
+++ b/components/SearchbarMobile.tsx
@@ -13,15 +13,13 @@ const SearchbarMobile = () => {
         data={["Smink", "Läppstift"]}
         styles={{
           input: {
-          color: "white"
+            color: "white",
           },
         }}
         sx={(theme) => ({
           width: "100%",
+          height: 40,
           backgroundColor: theme.colors.brand[2],
-          [theme.fn.largerThan("xs")]: {
-            display: "none",
-          },
         })}
       ></Autocomplete>
     </Flex>

--- a/components/layout/MarginTopContainer.tsx
+++ b/components/layout/MarginTopContainer.tsx
@@ -1,0 +1,23 @@
+import { Flex } from "@mantine/core";
+import { FC, PropsWithChildren } from "react";
+
+const MarginTopContainer: FC<PropsWithChildren> = ({ children }) => {
+  return (
+    <Flex
+      sx={(theme) => ({
+        width: "100%",
+        flexDirection: "column",
+        marginTop: 200,
+        [theme.fn.smallerThan("md")]: {
+          marginTop: 180,
+        },
+        [theme.fn.smallerThan("sm")]: { marginTop: 150 },
+        [theme.fn.smallerThan("xs")]: { marginTop: 0 },
+      })}
+    >
+      {children}
+    </Flex>
+  );
+};
+
+export default MarginTopContainer;

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -3,18 +3,21 @@ import { NextPage } from "next";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 import { useSession, signIn, signOut } from "next-auth/react";
+import MarginTopContainer from "../../components/layout/MarginTopContainer";
 
 const Admin: NextPage = () => {
   const { data: session } = useSession();
   return (
     <>
       <AppShell fixed={false} header={<Header />} footer={<Footer />}>
-        <Box style={{ marginTop: 60, minHeight: "100vh" }}>
-          <Title order={1}>Du är på adminsidan</Title>
-          <Button mx={10} color="white" onClick={() => signOut()}>
-            Logga ut
-          </Button>
-        </Box>
+        <MarginTopContainer>
+          <Box style={{ marginTop: 60, minHeight: "100vh" }}>
+            <Title order={1}>Du är på adminsidan</Title>
+            <Button mx={10} color="white" onClick={() => signOut()}>
+              Logga ut
+            </Button>
+          </Box>
+        </MarginTopContainer>
       </AppShell>
     </>
   );

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -16,6 +16,7 @@ import SignUpForm from "../../components/auth/SignUpForm";
 import Cart from "../../components/cart/Cart";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
+import MarginTopContainer from "../../components/layout/MarginTopContainer";
 
 const SignIn: NextPage = () => {
   const session = useSession();
@@ -46,128 +47,130 @@ const SignIn: NextPage = () => {
         header={<Header />}
         footer={<Footer />}
       >
-        <Flex
-          justify="center"
-          align="center"
-          sx={(theme) => ({
-            minHeight: "100vh",
-            backgroundColor: theme.white,
-            [theme.fn.smallerThan(600)]: {
-              marginTop: 50,
-            },
-            [theme.fn.smallerThan(500)]: {
-              alignItems: "flex-start",
-              marginTop: 100,
-              marginBottom: 100,
-            },
-          })}
-        >
-          <Box
-            p={32}
+        <MarginTopContainer>
+          <Flex
+            justify="center"
+            align="center"
             sx={(theme) => ({
-              backgroundColor: theme.black,
-              borderRadius: "8px",
-              width: "430px",
-              [theme.fn.smallerThan(500)]: {
-                width: "90%",
-                backgroundColor: theme.white,
+              minHeight: "100vh",
+              backgroundColor: theme.white,
+              [theme.fn.smallerThan(600)]: {
+                marginTop: 50,
               },
-              [theme.fn.smallerThan(400)]: {
-                width: "95%",
+              [theme.fn.smallerThan(500)]: {
+                alignItems: "flex-start",
+                marginTop: 100,
+                marginBottom: 100,
               },
             })}
           >
-            {showSignUp ? (
-              <Container
-                sx={(theme) => ({
-                  [theme.fn.smallerThan(500)]: {
-                    width: "100%",
-                  },
-                })}
-              >
-                <Title
-                  color="white"
-                  order={3}
-                  transform="uppercase"
+            <Box
+              p={32}
+              sx={(theme) => ({
+                backgroundColor: theme.black,
+                borderRadius: "8px",
+                width: "430px",
+                [theme.fn.smallerThan(500)]: {
+                  width: "90%",
+                  backgroundColor: theme.white,
+                },
+                [theme.fn.smallerThan(400)]: {
+                  width: "95%",
+                },
+              })}
+            >
+              {showSignUp ? (
+                <Container
                   sx={(theme) => ({
                     [theme.fn.smallerThan(500)]: {
-                      color: theme.black,
+                      width: "100%",
                     },
                   })}
                 >
-                  Skapa konto
-                </Title>
-                <SignUpForm />
-                <Button
-                  mt="lg"
-                  fullWidth
-                  onClick={() => {
-                    setShowSignUp(false);
-                    setToggleButtonText("Registrera/Skapa konto");
-                  }}
+                  <Title
+                    color="white"
+                    order={3}
+                    transform="uppercase"
+                    sx={(theme) => ({
+                      [theme.fn.smallerThan(500)]: {
+                        color: theme.black,
+                      },
+                    })}
+                  >
+                    Skapa konto
+                  </Title>
+                  <SignUpForm />
+                  <Button
+                    mt="lg"
+                    fullWidth
+                    onClick={() => {
+                      setShowSignUp(false);
+                      setToggleButtonText("Registrera/Skapa konto");
+                    }}
+                    sx={(theme) => ({
+                      backgroundColor: theme.black,
+                      "&:hover": {
+                        backgroundColor: theme.colors.grape[2],
+                      },
+                      [theme.fn.smallerThan(500)]: {
+                        color: theme.black,
+                        backgroundColor: theme.white,
+                      },
+                    })}
+                  >
+                    {toggleButtonText}
+                  </Button>
+                </Container>
+              ) : (
+                <Container
                   sx={(theme) => ({
-                    backgroundColor: theme.black,
-                    "&:hover": {
-                      backgroundColor: theme.colors.grape[2],
-                    },
+                    minWidth: 352,
                     [theme.fn.smallerThan(500)]: {
-                      color: theme.black,
-                      backgroundColor: theme.white,
+                      minWidth: "90%",
+                    },
+                    [theme.fn.smallerThan(400)]: {
+                      minWidth: "95%",
                     },
                   })}
                 >
-                  {toggleButtonText}
-                </Button>
-              </Container>
-            ) : (
-              <Container
-                sx={(theme) => ({
-                  minWidth: 352,
-                  [theme.fn.smallerThan(500)]: {
-                    minWidth: "90%",
-                  },
-                  [theme.fn.smallerThan(400)]: {
-                    minWidth: "95%",
-                  },
-                })}
-              >
-                <Title
-                  color="white"
-                  order={3}
-                  transform="uppercase"
-                  sx={(theme) => ({
-                    [theme.fn.smallerThan(500)]: {
-                      color: theme.black,
-                    },
-                  })}
-                >
-                  Logga in
-                </Title>
-                <SignInForm />
-                <Button
-                  mt="lg"
-                  fullWidth
-                  onClick={() => {
-                    setShowSignUp(true);
-                    setToggleButtonText("Gå tillbaka till inloggning");
-                  }}
-                  sx={(theme) => ({
-                    backgroundColor: theme.black,
-                    "&:hover": {
-                      backgroundColor: theme.colors.red[4],
-                    },
-                    [theme.fn.smallerThan(500)]: {
-                      color: theme.black,
-                      backgroundColor: theme.white,
-                    },
-                  })}
-                >
-                  {toggleButtonText}
-                </Button>
-              </Container>
-            )}
-          </Box>
-        </Flex>
+                  <Title
+                    color="white"
+                    order={3}
+                    transform="uppercase"
+                    sx={(theme) => ({
+                      [theme.fn.smallerThan(500)]: {
+                        color: theme.black,
+                      },
+                    })}
+                  >
+                    Logga in
+                  </Title>
+                  <SignInForm />
+                  <Button
+                    mt="lg"
+                    fullWidth
+                    onClick={() => {
+                      setShowSignUp(true);
+                      setToggleButtonText("Gå tillbaka till inloggning");
+                    }}
+                    sx={(theme) => ({
+                      backgroundColor: theme.black,
+                      "&:hover": {
+                        backgroundColor: theme.colors.red[4],
+                      },
+                      [theme.fn.smallerThan(500)]: {
+                        color: theme.black,
+                        backgroundColor: theme.white,
+                      },
+                    })}
+                  >
+                    {toggleButtonText}
+                  </Button>
+                </Container>
+              )}
+            </Box>
+          </Flex>
+        </MarginTopContainer>
         <Cart />
       </AppShell>
     </>

--- a/pages/minsida.tsx
+++ b/pages/minsida.tsx
@@ -9,6 +9,7 @@ import OrderSummary from "../components/OrderSummary";
 import WrapContainer from "../components/layout/WrapContainer";
 import useFetchHelper from "../utils/useFetchHelper";
 import ErrorPage from "./ErrorPage";
+import MarginTopContainer from "../components/layout/MarginTopContainer";
 
 const MyPage: NextPage = () => {
   const { data: session } = useSession();
@@ -47,110 +48,114 @@ const MyPage: NextPage = () => {
           },
         }}
       >
-        <WrapContainer>
-          <Title
-            sx={(theme) => ({
-              [theme.fn.smallerThan("xs")]: {
-                fontSize: 30,
-              },
-            })}
-            order={1}
-          >
-            Välkommen {session?.user.name.replace(/ .*/, "")} !
-          </Title>
-          <Text align="center">Nedan kan du se dina senaste beställningar</Text>
-          <Flex
-            direction={"column"}
-            mt={40}
-            mb={40}
-            justify={"center"}
-            align="center"
-            sx={{ width: "100%" }}
-          >
-            {orders ? (
-              orders.map((order: any) => {
-                return (
-                  <Accordion
-                    styles={{ control: { padding: 5 } }}
-                    sx={(theme) => ({
-                      marginTop: 20,
-                      width: "550px",
-                      [theme.fn.smallerThan("sm")]: {
-                        width: "470px",
-                      },
-                      [theme.fn.smallerThan("xs")]: {
-                        width: "100%",
-                        padding: 0,
-                      },
-                    })}
-                    defaultValue={null}
-                  >
-                    <Accordion.Item value="customization">
-                      <Accordion.Control>
-                        <Flex justify={"space-between"} align={"center"}>
-                          <Text
-                            sx={(theme) => ({
-                              [theme.fn.smallerThan("xs")]: {
-                                fontSize: 14,
-                              },
-                            })}
-                          >
-                            Order: {order.orderNo}
-                          </Text>
-                          <Flex align={"center"} gap={15}>
+        <MarginTopContainer>
+          <WrapContainer>
+            <Title
+              sx={(theme) => ({
+                [theme.fn.smallerThan("xs")]: {
+                  fontSize: 30,
+                },
+              })}
+              order={1}
+            >
+              Välkommen {session?.user.name.replace(/ .*/, "")} !
+            </Title>
+            <Text align="center">
+              Nedan kan du se dina senaste beställningar
+            </Text>
+            <Flex
+              direction={"column"}
+              mt={40}
+              mb={40}
+              justify={"center"}
+              align="center"
+              sx={{ width: "100%" }}
+            >
+              {orders ? (
+                orders.map((order: any) => {
+                  return (
+                    <Accordion
+                      styles={{ control: { padding: 5 } }}
+                      sx={(theme) => ({
+                        marginTop: 20,
+                        width: "550px",
+                        [theme.fn.smallerThan("sm")]: {
+                          width: "470px",
+                        },
+                        [theme.fn.smallerThan("xs")]: {
+                          width: "100%",
+                          padding: 0,
+                        },
+                      })}
+                      defaultValue={null}
+                    >
+                      <Accordion.Item value="customization">
+                        <Accordion.Control>
+                          <Flex justify={"space-between"} align={"center"}>
                             <Text
-                              size={14}
                               sx={(theme) => ({
                                 [theme.fn.smallerThan("xs")]: {
-                                  fontSize: 11,
+                                  fontSize: 14,
                                 },
                               })}
                             >
-                              {order.shippingDate
-                                ? order.shippingDate
-                                : order.registerDate}
+                              Order: {order.orderNo}
                             </Text>
-                            <Flex
-                              p={6}
-                              pt={2}
-                              pb={2}
-                              bg={order.status.color}
-                              sx={(theme) => ({
-                                borderRadius: "7px",
-                                [theme.fn.smallerThan("xs")]: {
-                                  padding: 4,
-                                },
-                              })}
-                            >
+                            <Flex align={"center"} gap={15}>
                               <Text
+                                size={14}
                                 sx={(theme) => ({
                                   [theme.fn.smallerThan("xs")]: {
-                                    fontSize: 10,
+                                    fontSize: 11,
                                   },
                                 })}
-                                size={12}
                               >
-                                {order.status.status}
+                                {order.shippingDate
+                                  ? order.shippingDate
+                                  : order.registerDate}
                               </Text>
+                              <Flex
+                                p={6}
+                                pt={2}
+                                pb={2}
+                                bg={order.status.color}
+                                sx={(theme) => ({
+                                  borderRadius: "7px",
+                                  [theme.fn.smallerThan("xs")]: {
+                                    padding: 4,
+                                  },
+                                })}
+                              >
+                                <Text
+                                  sx={(theme) => ({
+                                    [theme.fn.smallerThan("xs")]: {
+                                      fontSize: 10,
+                                    },
+                                  })}
+                                  size={12}
+                                >
+                                  {order.status.status}
+                                </Text>
+                              </Flex>
                             </Flex>
                           </Flex>
-                        </Flex>
-                      </Accordion.Control>
-                      <Accordion.Panel>
-                        <OrderSummary order={order} />
-                      </Accordion.Panel>
-                    </Accordion.Item>
-                  </Accordion>
-                );
-              })
-            ) : (
-              <Text>Du har ännu inte lagt en order</Text>
-            )}
-          </Flex>
-          <Button mx={10} color="white" onClick={() => signOut()}>
-            Logga ut
-          </Button>
-        </WrapContainer>
+                        </Accordion.Control>
+                        <Accordion.Panel>
+                          <OrderSummary order={order} />
+                        </Accordion.Panel>
+                      </Accordion.Item>
+                    </Accordion>
+                  );
+                })
+              ) : (
+                <Text>Du har ännu inte lagt en order</Text>
+              )}
+            </Flex>
+            <Button mx={10} color="white" onClick={() => signOut()}>
+              Logga ut
+            </Button>
+          </WrapContainer>
+        </MarginTopContainer>
         <Cart />
       </AppShell>
     </>

--- a/pages/produkt/[slug].tsx
+++ b/pages/produkt/[slug].tsx
@@ -23,6 +23,7 @@ import Cart from "../../components/cart/Cart";
 import { openedCartContext } from "../../components/context/OpenCartProvider";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
+import MarginTopContainer from "../../components/layout/MarginTopContainer";
 import CarouselProduct from "../../components/product/CarouselProduct";
 import Details from "../../components/product/Details";
 import { SeasonDocument } from "../../models/Season";
@@ -160,271 +161,276 @@ const ProductPage: NextPage = (props) => {
         },
       }}
     >
-      <Flex sx={{ width: "100%" }}>
-        <Breadcrumbs>
-          <BreadCrumb href={"/"} title={"Hem"} />
-          <BreadCrumb href={"/"} title={""} />
-        </Breadcrumbs>
-        <Text
-          sx={{ cursor: "pointer" }}
-          onClick={() => router.back()}
-          color={"brand.6"}
-          size={"sm"}
-        >
-          Tillbaka
-        </Text>
-      </Flex>
+      <MarginTopContainer>
+        <Flex sx={{ width: "100%" }}>
+          <Breadcrumbs>
+            <BreadCrumb href={"/"} title={"Hem"} />
+            <BreadCrumb href={"/"} title={""} />
+          </Breadcrumbs>
+          <Text
+            sx={{ cursor: "pointer" }}
+            onClick={() => router.back()}
+            color={"brand.6"}
+            size={"sm"}
+          >
+            Tillbaka
+          </Text>
+        </Flex>
 
-      <Box
-        style={{
-          marginTop: 30,
-          minHeight: "100vh",
-          width: "100%",
-          maxWidth: "1320px",
-        }}
-      >
-        {product && product.mainProduct && products ? (
-          <Flex direction={"column"} sx={{ width: "100%" }}>
-            <Flex
-              sx={(theme) => ({
-                width: "100%",
-                [theme.fn.smallerThan("xs")]: {
-                  flexDirection: "column",
-                },
-              })}
-              gap={20}
-            >
+        <Box
+          style={{
+            marginTop: 30,
+            minHeight: "100vh",
+            width: "100%",
+            maxWidth: "1320px",
+          }}
+        >
+          {product && product.mainProduct && products ? (
+            <Flex direction={"column"} sx={{ width: "100%" }}>
               <Flex
                 sx={(theme) => ({
-                  width: "50%",
+                  width: "100%",
                   [theme.fn.smallerThan("xs")]: {
-                    width: "100%",
+                    flexDirection: "column",
                   },
                 })}
-                align="flex-start"
+                gap={20}
               >
-                <Carousel
-                  classNames={classes}
-                  mx="auto"
-                  align="center"
-                  height={"55vh"}
-                  styles={(theme) => ({
-                    viewport: {
-                      [theme.fn.smallerThan("xs")]: {
-                        height: "40vh",
-                      },
-                    },
-                    container: {
-                      [theme.fn.smallerThan("xs")]: {
-                        height: "40vh",
-                      },
+                <Flex
+                  sx={(theme) => ({
+                    width: "50%",
+                    [theme.fn.smallerThan("xs")]: {
+                      width: "100%",
                     },
                   })}
-                  loop
-                  slideSize={"101%"}
+                  align="flex-start"
                 >
-                  {product.images ? (
-                    product.images.map((image: string, index: number) => {
-                      return (
-                        <Carousel.Slide key={index}>
-                          <Image
-                            fit="contain"
-                            styles={{
-                              root: {
-                                display: "flex",
-                                align: "center",
-                                justifyContent: "center",
-                              },
-                              imageWrapper: {
-                                display: "flex",
-                                align: "center",
-                              },
-                              figure: {
-                                display: "flex",
-                                align: "center",
-                              },
-                            }}
-                            src={`/uploads/${image}`}
-                          />
-                        </Carousel.Slide>
-                      );
-                    })
-                  ) : (
-                    <Carousel.Slide></Carousel.Slide>
-                  )}
-                </Carousel>
-              </Flex>
-              <Flex
-                sx={(theme) => ({
-                  width: "50%",
-                  [theme.fn.smallerThan("xs")]: {
-                    width: "100%",
-                  },
-                })}
-                direction={"column"}
-              >
-                <Flex direction={"column"}>
-                  <Title color="dimmed" order={5}>
-                    {product.mainProduct.brand}
-                  </Title>
-                  <Title order={1}>{product.title}</Title>
+                  <Carousel
+                    classNames={classes}
+                    mx="auto"
+                    align="center"
+                    height={"55vh"}
+                    styles={(theme) => ({
+                      viewport: {
+                        [theme.fn.smallerThan("xs")]: {
+                          height: "40vh",
+                        },
+                      },
+                      container: {
+                        [theme.fn.smallerThan("xs")]: {
+                          height: "40vh",
+                        },
+                      },
+                    })}
+                    loop
+                    slideSize={"101%"}
+                  >
+                    {product.images ? (
+                      product.images.map((image: string, index: number) => {
+                        return (
+                          <Carousel.Slide key={index}>
+                            <Image
+                              fit="contain"
+                              styles={{
+                                root: {
+                                  display: "flex",
+                                  align: "center",
+                                  justifyContent: "center",
+                                },
+                                imageWrapper: {
+                                  display: "flex",
+                                  align: "center",
+                                },
+                                figure: {
+                                  display: "flex",
+                                  align: "center",
+                                },
+                              }}
+                              src={`/uploads/${image}`}
+                            />
+                          </Carousel.Slide>
+                        );
+                      })
+                    ) : (
+                      <Carousel.Slide></Carousel.Slide>
+                    )}
+                  </Carousel>
                 </Flex>
-                <Flex justify={"space-between"}>
-                  <Flex>
-                    <MediaQuery smallerThan={"xs"} styles={{ display: "none" }}>
-                      <Text>
-                        {product.mainProduct.price.$numberDecimal + " KR"}
-                      </Text>
-                    </MediaQuery>
+                <Flex
+                  sx={(theme) => ({
+                    width: "50%",
+                    [theme.fn.smallerThan("xs")]: {
+                      width: "100%",
+                    },
+                  })}
+                  direction={"column"}
+                >
+                  <Flex direction={"column"}>
+                    <Title color="dimmed" order={5}>
+                      {product.mainProduct.brand}
+                    </Title>
+                    <Title order={1}>{product.title}</Title>
                   </Flex>
-                  <Flex>
-                    {product.colors
-                      ? product.colors.map((color: any) => {
-                          return color.seasons.map(
-                            (season: SeasonDocument, index: number) => {
-                              return (
-                                <Tooltip
-                                  key={index}
-                                  color="black"
-                                  label={season.title}
-                                  withArrow
-                                >
-                                  <Flex
-                                    mt={10}
+                  <Flex justify={"space-between"}>
+                    <Flex>
+                      <MediaQuery
+                        smallerThan={"xs"}
+                        styles={{ display: "none" }}
+                      >
+                        <Text>
+                          {product.mainProduct.price.$numberDecimal + " KR"}
+                        </Text>
+                      </MediaQuery>
+                    </Flex>
+                    <Flex>
+                      {product.colors
+                        ? product.colors.map((color: any) => {
+                            return color.seasons.map(
+                              (season: SeasonDocument, index: number) => {
+                                return (
+                                  <Tooltip
                                     key={index}
-                                    mr={20}
-                                    w={30}
-                                    h={30}
-                                    justify="center"
-                                    align="center"
-                                    sx={(theme) => ({
-                                      borderRadius: "50%",
-                                      border: "1px solid black",
-                                      [theme.fn.smallerThan("md")]: {
-                                        marginRight: 10,
-                                        width: 25,
-                                        height: 25,
-                                      },
-                                    })}
+                                    color="black"
+                                    label={season.title}
+                                    withArrow
                                   >
-                                    <Text
-                                      color={"black"}
-                                      size={"sm"}
+                                    <Flex
+                                      mt={10}
+                                      key={index}
+                                      mr={20}
+                                      w={30}
+                                      h={30}
+                                      justify="center"
+                                      align="center"
                                       sx={(theme) => ({
+                                        borderRadius: "50%",
+                                        border: "1px solid black",
                                         [theme.fn.smallerThan("md")]: {
-                                          fontSize: theme.fontSizes.xs,
+                                          marginRight: 10,
+                                          width: 25,
+                                          height: 25,
                                         },
                                       })}
                                     >
-                                      {season.title.slice(0, 2)}
-                                    </Text>
-                                  </Flex>
-                                </Tooltip>
-                              );
-                            }
-                          );
-                        })
-                      : null}
+                                      <Text
+                                        color={"black"}
+                                        size={"sm"}
+                                        sx={(theme) => ({
+                                          [theme.fn.smallerThan("md")]: {
+                                            fontSize: theme.fontSizes.xs,
+                                          },
+                                        })}
+                                      >
+                                        {season.title.slice(0, 2)}
+                                      </Text>
+                                    </Flex>
+                                  </Tooltip>
+                                );
+                              }
+                            );
+                          })
+                        : null}
+                    </Flex>
                   </Flex>
-                </Flex>
 
-                <Flex mt={20} gap={10} direction={"column"}>
-                  <Text size={14}>{product.mainProduct.description1}</Text>
-                  <Text size={14}>
-                    {product.mainProduct.description2
-                      ? product.mainProduct.description2
-                      : null}
-                  </Text>
+                  <Flex mt={20} gap={10} direction={"column"}>
+                    <Text size={14}>{product.mainProduct.description1}</Text>
+                    <Text size={14}>
+                      {product.mainProduct.description2
+                        ? product.mainProduct.description2
+                        : null}
+                    </Text>
+                  </Flex>
+                  {product.availableQty < 1 ? (
+                    <Text mt={20} size={14} color="red">
+                      Tillfällig slut
+                    </Text>
+                  ) : null}
+                  <MediaQuery smallerThan={"xs"} styles={{ display: "none" }}>
+                    <Button
+                      disabled={product.availableQty < 1 ? true : false}
+                      mt={20}
+                      onClick={() => handleClick()}
+                    >
+                      KÖP NU
+                    </Button>
+                  </MediaQuery>
+                  <MediaQuery smallerThan={"sm"} styles={{ display: "none" }}>
+                    <Box>
+                      <Details product={product} />
+                    </Box>
+                  </MediaQuery>
                 </Flex>
-                {product.availableQty < 1 ? (
-                  <Text mt={20} size={14} color="red">
-                    Tillfällig slut
-                  </Text>
-                ) : null}
-                <MediaQuery smallerThan={"xs"} styles={{ display: "none" }}>
-                  <Button
-                    disabled={product.availableQty < 1 ? true : false}
-                    mt={20}
-                    onClick={() => handleClick()}
-                  >
-                    KÖP NU
-                  </Button>
-                </MediaQuery>
-                <MediaQuery smallerThan={"sm"} styles={{ display: "none" }}>
+              </Flex>
+
+              <MediaQuery largerThan={"sm"} styles={{ display: "none" }}>
+                <Box>
+                  <Details product={product} />
+                </Box>
+              </MediaQuery>
+              <Flex direction={"column"} mt={20} sx={{ width: "100%" }}>
+                <Title order={3}>Andra har också köpt</Title>
+                <MediaQuery smallerThan={"lg"} styles={{ display: "none" }}>
                   <Box>
-                    <Details product={product} />
+                    <CarouselProduct
+                      products={products}
+                      slideGap="md"
+                      slideSize="30.3333%"
+                      slidesToScroll={undefined}
+                    />
+                  </Box>
+                </MediaQuery>
+                <MediaQuery
+                  query="(max-width: 767px) or (min-width: 1200px)"
+                  styles={{ display: "none" }}
+                >
+                  <Box>
+                    <CarouselProduct
+                      products={products}
+                      slideGap="md"
+                      slideSize="50%"
+                      slidesToScroll={2}
+                    />
+                  </Box>
+                </MediaQuery>
+                <MediaQuery largerThan={"sm"} styles={{ display: "none" }}>
+                  <Box>
+                    <CarouselProduct
+                      products={products}
+                      slideGap="xs"
+                      slideSize="100%"
+                      slidesToScroll={undefined}
+                    />
                   </Box>
                 </MediaQuery>
               </Flex>
-            </Flex>
 
-            <MediaQuery largerThan={"sm"} styles={{ display: "none" }}>
-              <Box>
-                <Details product={product} />
-              </Box>
-            </MediaQuery>
-            <Flex direction={"column"} mt={20} sx={{ width: "100%" }}>
-              <Title order={3}>Andra har också köpt</Title>
-              <MediaQuery smallerThan={"lg"} styles={{ display: "none" }}>
-                <Box>
-                  <CarouselProduct
-                    products={products}
-                    slideGap="md"
-                    slideSize="30.3333%"
-                    slidesToScroll={undefined}
-                  />
-                </Box>
-              </MediaQuery>
-              <MediaQuery
-                query="(max-width: 767px) or (min-width: 1200px)"
-                styles={{ display: "none" }}
-              >
-                <Box>
-                  <CarouselProduct
-                    products={products}
-                    slideGap="md"
-                    slideSize="50%"
-                    slidesToScroll={2}
-                  />
-                </Box>
-              </MediaQuery>
-              <MediaQuery largerThan={"sm"} styles={{ display: "none" }}>
-                <Box>
-                  <CarouselProduct
-                    products={products}
-                    slideGap="xs"
-                    slideSize="100%"
-                    slidesToScroll={undefined}
-                  />
-                </Box>
-              </MediaQuery>
+              {product.availableQty < 1 ? null : (
+                <MediaQuery largerThan={"xs"} styles={{ display: "none" }}>
+                  <Flex
+                    pos={"fixed"}
+                    bottom={0}
+                    right={0}
+                    left={0}
+                    h={70}
+                    bg="gray.2"
+                    justify={"space-between"}
+                    align="center"
+                    px={20}
+                    sx={{ zIndex: 3 }}
+                  >
+                    <Text weight={"bold"}>
+                      {" "}
+                      {product.mainProduct.price.$numberDecimal + " KR"}
+                    </Text>
+                    <Button onClick={() => handleClick()}>KÖP NU</Button>
+                  </Flex>
+                </MediaQuery>
+              )}
             </Flex>
-
-            {product.availableQty < 1 ? null : (
-              <MediaQuery largerThan={"xs"} styles={{ display: "none" }}>
-                <Flex
-                  pos={"fixed"}
-                  bottom={0}
-                  right={0}
-                  left={0}
-                  h={70}
-                  bg="gray.2"
-                  justify={"space-between"}
-                  align="center"
-                  px={20}
-                  sx={{ zIndex: 3 }}
-                >
-                  <Text weight={"bold"}>
-                    {" "}
-                    {product.mainProduct.price.$numberDecimal + " KR"}
-                  </Text>
-                  <Button onClick={() => handleClick()}>KÖP NU</Button>
-                </Flex>
-              </MediaQuery>
-            )}
-          </Flex>
-        ) : null}
-      </Box>
+          ) : null}
+        </Box>
+      </MarginTopContainer>
       <Cart />
     </AppShell>
   );

--- a/pages/season/[seasonSlug]/category/[...categorySlug].tsx
+++ b/pages/season/[seasonSlug]/category/[...categorySlug].tsx
@@ -15,6 +15,7 @@ import BreadCrumb from "../../../../components/BreadCrumb";
 import Cart from "../../../../components/cart/Cart";
 import Footer from "../../../../components/Footer";
 import Header from "../../../../components/Header";
+import MarginTopContainer from "../../../../components/layout/MarginTopContainer";
 import WrapContainer from "../../../../components/layout/WrapContainer";
 import ProductCard from "../../../../components/ProductCard";
 import { CategoryDocument } from "../../../../models/Category";
@@ -69,52 +70,54 @@ const CategoryPage: NextPage = (props) => {
       fixed={false}
       header={<Header />}
       footer={<Footer />}
-      styles={{
+      styles={(theme) => ({
         main: {
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
         },
-      }}
+      })}
     >
-      {!season || !category ? null : (
-        <Flex sx={{ width: "100%" }}>
-          <Breadcrumbs>
-            <BreadCrumb href={"/"} title={"Hem"} />
-            <BreadCrumb
-              href={`/season/${season?.slug}`}
-              title={season?.title}
-            />
-            <BreadCrumb
-              href={`/season/${season?.slug}/category/${categorySlug}`}
-              title={category?.title}
-            />
-          </Breadcrumbs>
-        </Flex>
-      )}
-      <WrapContainer>
-        {!products ? null : (
-          <>
-            <Flex direction={"column"} align="center" sx={{ width: "100%" }}>
-              <Title order={1}>{category?.title}</Title>
-              <Text color="dimmed">{category?.description}</Text>
-            </Flex>
-            {products ? (
-              <Flex mt="xl" wrap="wrap" justify={"center"}>
-                <Grid justify={"center"}>
-                  {products?.map((product: any, index: number) => {
-                    return (
-                      <Grid.Col key={index} md={4} sm={5} xs={6}>
-                        <ProductCard product={product} />
-                      </Grid.Col>
-                    );
-                  })}
-                </Grid>
-              </Flex>
-            ) : null}
-          </>
+      <MarginTopContainer>
+        {!season || !category ? null : (
+          <Flex sx={{ width: "100%" }}>
+            <Breadcrumbs>
+              <BreadCrumb href={"/"} title={"Hem"} />
+              <BreadCrumb
+                href={`/season/${season?.slug}`}
+                title={season?.title}
+              />
+              <BreadCrumb
+                href={`/season/${season?.slug}/category/${categorySlug}`}
+                title={category?.title}
+              />
+            </Breadcrumbs>
+          </Flex>
         )}
-      </WrapContainer>
+        <WrapContainer>
+          {!products ? null : (
+            <>
+              <Flex direction={"column"} align="center" sx={{ width: "100%" }}>
+                <Title order={1}>{category?.title}</Title>
+                <Text color="dimmed">{category?.description}</Text>
+              </Flex>
+              {products ? (
+                <Flex mt="xl" wrap="wrap" justify={"center"}>
+                  <Grid justify={"center"}>
+                    {products?.map((product: any, index: number) => {
+                      return (
+                        <Grid.Col key={index} md={4} sm={5} xs={6}>
+                          <ProductCard product={product} />
+                        </Grid.Col>
+                      );
+                    })}
+                  </Grid>
+                </Flex>
+              ) : null}
+            </>
+          )}
+        </WrapContainer>
+      </MarginTopContainer>
       <Cart />
     </AppShell>
   );

--- a/pages/season/[seasonSlug]/index.tsx
+++ b/pages/season/[seasonSlug]/index.tsx
@@ -7,6 +7,8 @@ import {
   Title,
   Text,
   Breadcrumbs,
+  Sx,
+  MantineTheme,
 } from "@mantine/core";
 import { NextPage } from "next";
 import Link from "next/link";
@@ -16,6 +18,7 @@ import BreadCrumb from "../../../components/BreadCrumb";
 import Cart from "../../../components/cart/Cart";
 import Footer from "../../../components/Footer";
 import Header from "../../../components/Header";
+import MarginTopContainer from "../../../components/layout/MarginTopContainer";
 import WrapContainer from "../../../components/layout/WrapContainer";
 import ProductCard from "../../../components/ProductCard";
 import { CategoryDocument } from "../../../models/Category";
@@ -28,7 +31,6 @@ const SeasonPage: NextPage = (props) => {
   const { seasonSlug } = router.query;
   const [products, setProducts] = useState<any>([]);
   const [season, setSeason] = useState<SeasonDocument>();
-  const [openedCart, setOpenedCart] = useState(false);
   const [status, setStatus] = useState(200);
   const [isLoadingProducts, setIsLoadingProducts] = useState(true);
   const [isLoadingSeason, setIsLoadingSeason] = useState(true);
@@ -74,62 +76,64 @@ const SeasonPage: NextPage = (props) => {
       fixed={false}
       header={<Header />}
       footer={<Footer />}
-      styles={{
+      styles={(theme) => ({
         main: {
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
         },
-      }}
+      })}
     >
-      {!season ? null : (
-        <Flex sx={{ width: "100%" }}>
-          <Breadcrumbs>
-            <BreadCrumb href={"/"} title={"Hem"} />
-            <BreadCrumb
-              href={`/season/${season?.slug}`}
-              title={season?.title}
-            />
-          </Breadcrumbs>
-        </Flex>
-      )}
-      <WrapContainer>
-        {!products ? null : (
-          <>
-            <Flex direction={"column"} align="center" sx={{ width: "100%" }}>
-              <Title order={1}>{season?.title}</Title>
-              <Text color="dimmed">{season?.description}</Text>
-            </Flex>
-            {products[0] ? (
-              <Flex justify={"center"} mt="sm" gap="lg" wrap={"wrap"}>
-                {categories.map((category, index) => {
-                  return (
-                    <Link
-                      key={index}
-                      href={`/season/${seasonSlug}/category/${category.slug}`}
-                    >
-                      <Button variant="outline" color="brand.2">
-                        {category.title}
-                      </Button>
-                    </Link>
-                  );
-                })}
-              </Flex>
-            ) : null}
-            <Flex mt="xl" wrap="wrap" justify={"center"}>
-              <Grid justify={"center"}>
-                {products?.map((product: any, index: number) => {
-                  return (
-                    <Grid.Col key={index} md={4} sm={5} xs={6}>
-                      <ProductCard product={product} />
-                    </Grid.Col>
-                  );
-                })}
-              </Grid>
-            </Flex>
-          </>
+      <MarginTopContainer>
+        {!season ? null : (
+          <Flex sx={{ width: "100%" }}>
+            <Breadcrumbs>
+              <BreadCrumb href={"/"} title={"Hem"} />
+              <BreadCrumb
+                href={`/season/${season?.slug}`}
+                title={season?.title}
+              />
+            </Breadcrumbs>
+          </Flex>
         )}
-      </WrapContainer>
+        <WrapContainer>
+          {!products ? null : (
+            <>
+              <Flex direction={"column"} align="center" sx={{ width: "100%" }}>
+                <Title order={1}>{season?.title}</Title>
+                <Text color="dimmed">{season?.description}</Text>
+              </Flex>
+              {products[0] ? (
+                <Flex justify={"center"} mt="sm" gap="lg" wrap={"wrap"}>
+                  {categories.map((category, index) => {
+                    return (
+                      <Link
+                        key={index}
+                        href={`/season/${seasonSlug}/category/${category.slug}`}
+                      >
+                        <Button variant="outline" color="brand.2">
+                          {category.title}
+                        </Button>
+                      </Link>
+                    );
+                  })}
+                </Flex>
+              ) : null}
+              <Flex mt="xl" wrap="wrap" justify={"center"}>
+                <Grid justify={"center"}>
+                  {products?.map((product: any, index: number) => {
+                    return (
+                      <Grid.Col key={index} md={4} sm={5} xs={6}>
+                        <ProductCard product={product} />
+                      </Grid.Col>
+                    );
+                  })}
+                </Grid>
+              </Flex>
+            </>
+          )}
+        </WrapContainer>
+      </MarginTopContainer>
       <Cart />
     </AppShell>
   );


### PR DESCRIPTION
#122 Scroll fixad. Det enda jag inte lyckades med utan att det blev kaos på clienten var att få bort searchen ordentligt. Den kommer tillbaka om man är vid toppen för tillfället. 

Desktop scroll up:
![Skärmavbild 2023-01-11 kl  14 35 05](https://user-images.githubusercontent.com/90898648/211820702-454bd4de-0985-41ca-b6ee-91ca6733dadc.png)
Desktop scroll down:
![Skärmavbild 2023-01-11 kl  14 35 14](https://user-images.githubusercontent.com/90898648/211820847-d1a55d6e-eeda-47cb-9b90-13fa6172015e.png)

Tab scroll up: 
![Skärmavbild 2023-01-11 kl  14 34 34](https://user-images.githubusercontent.com/90898648/211820966-1f9085ab-26eb-4724-b9cd-d48560487687.png)

Tab scroll down:
![Skärmavbild 2023-01-11 kl  14 34 14](https://user-images.githubusercontent.com/90898648/211821022-06734622-4b51-4bf1-a757-4d23b5715d4e.png)

Mobile scroll up top: 
![Skärmavbild 2023-01-11 kl  14 33 55](https://user-images.githubusercontent.com/90898648/211821111-6ed1dd8e-d32a-4fd4-ab4f-87ee6cbc17b8.png)

Mobile scroll up: 
![Skärmavbild 2023-01-11 kl  14 33 44](https://user-images.githubusercontent.com/90898648/211821190-8776bd7e-fdf2-4f50-bc20-3c3aff8df6db.png)

Mobile scroll down: 
![Skärmavbild 2023-01-11 kl  14 33 34](https://user-images.githubusercontent.com/90898648/211821264-6bdb9bd1-a0c7-4ad5-84a8-95fda554a0db.png)
