### PR TITLE
Searchbar

### DIFF
--- a/components/SearchMobileFrontpage.tsx
+++ b/components/SearchMobileFrontpage.tsx
@@ -98,6 +98,7 @@ const SearchMobileFrontPage = () => {
           itemComponent={AutoCompleteItem}
           icon={<IconSearch color="white" size={15} stroke={3} />}
           rightSection={
+            value &&
             <Box sx={{ cursor: "pointer" }} onClick={handleClick}>
               <IconX id="iconX" color="white" size={20} stroke={2} />
             </Box>

--- a/components/Searchbar.tsx
+++ b/components/Searchbar.tsx
@@ -1,4 +1,4 @@
-import { Flex, Autocomplete, Group, Avatar, Text, Box } from "@mantine/core";
+import { Flex, Autocomplete, Group, Avatar, Text, Box, createStyles } from "@mantine/core";
 import { IconSearch, IconX } from "@tabler/icons";
 import { useRouter } from "next/router";
 import { forwardRef, useEffect, useState } from "react";
@@ -17,6 +17,7 @@ const Searchbar = () => {
   const [data, setData] = useState<PopulatedProduct[]>([]);
   const router = useRouter();
 
+  const { classes } = useStyles();
   // onclick x clear inputvalue searchfield
   const handleClick = () => {
     setValue("");
@@ -98,13 +99,15 @@ const Searchbar = () => {
       </Flex>
 
       <Autocomplete
+        classNames={{rightSection: classes.rightSection}}
         onItemSubmit={(item) => {
           router.push(`/produkt/${item.slug}`);
           setValue("");
         }}
         itemComponent={AutoCompleteItem}
         rightSection={
-          <Box sx={{ cursor: "pointer" }} onClick={handleClick}>
+          value &&
+          <Box className="aaaada" sx={{ cursor: "pointer", bottom: 0}} onClick={handleClick}>
             <IconX id="iconX" color="white" size={20} stroke={2} />
           </Box>
         }
@@ -140,5 +143,12 @@ const Searchbar = () => {
     </Flex>
   );
 };
+
+const useStyles = createStyles((theme) => ({
+  rightSection: {
+    justifyContent: "flex-end",
+    alignItems: "flex-end",
+  }
+}))
 
 export default Searchbar;

--- a/components/SearchbarMobile.tsx
+++ b/components/SearchbarMobile.tsx
@@ -75,6 +75,7 @@ const SearchbarMobile = () => {
         itemComponent={AutoCompleteItem}
         icon={<IconSearch color="white" size={15} stroke={3} />}
         rightSection={
+          value &&
           <Box sx={{ cursor: "pointer" }} onClick={handleClick}>
             <IconX id="iconX" color="white" size={20} stroke={2} />
           </Box>
@@ -94,6 +95,8 @@ const SearchbarMobile = () => {
         sx={(theme) => ({
           width: "100%",
           height: 40,
+          paddingRight: "12px",
+          paddingLeft: "12px",
           backgroundColor: theme.colors.brand[2],
         })}
       ></Autocomplete>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -79,6 +79,8 @@ const Home: NextPage<Props> = ({ product, products, seasons }) => {
     });
   });
 
+  console.log(products)
+
   return (
     <>
       <Head>
@@ -511,7 +513,7 @@ const Home: NextPage<Props> = ({ product, products, seasons }) => {
                 : null}
             </Grid>
 
-            {/* <Flex direction={"column"} mt={20} sx={{ width: "100%" }}>
+            <Flex direction={"column"} mt={20} sx={{ width: "100%" }}>
               <Text
                 align="center"
                 fw={800}
@@ -560,7 +562,7 @@ const Home: NextPage<Props> = ({ product, products, seasons }) => {
                   />
                 </Box>
               </MediaQuery>
-            </Flex> */}
+            </Flex>
           </main>
           <Cart />
           <Quiz opened={opened} setOpened={setOpened} />


### PR DESCRIPTION
#171 Har lagt till så att krysset inte syns om det inte finns något value i inputfältet. fixat till X iconen på desktop läge så den ligger snyggare. har fixat en liten padding på sidorna på searchen på original headern så det ser jämnare ut. (se vad du tycker hade så på startsidans header.)
![desktopsearch](https://user-images.githubusercontent.com/90723670/214279888-a8ca542a-c710-45c6-a3b3-8ae60c43baa5.jpg)
![head](https://user-images.githubusercontent.com/90723670/214280017-1d7fb856-44a6-40cc-8965-1927a09b456c.jpg)
